### PR TITLE
Add iteration-aware execution output

### DIFF
--- a/optimization/execute.py
+++ b/optimization/execute.py
@@ -116,7 +116,7 @@ def run_scripts_with_chunk(code_list, test_input_list, time_limit_list, worker, 
         i += 1
     return exe_results
 
-def execute_scripts(outputs_name, num_chunks):
+def execute_scripts(outputs_name, num_chunks, iteration=None):
 
     os.makedirs(os.path.dirname("./temp_data/outputs-" + outputs_name + '.json'), exist_ok=True)
     with open("./temp_data/outputs-" + outputs_name + '.json', 'r') as f:
@@ -271,6 +271,11 @@ def execute_scripts(outputs_name, num_chunks):
     os.makedirs(os.path.dirname("./temp_data/outputs-" + outputs_name + ".json"), exist_ok=True)
     with open("./temp_data/outputs-" + outputs_name + ".json", "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
+    if iteration is not None:
+        iter_path = f"./temp_data/outputs-{outputs_name}-iter{iteration}.json"
+        os.makedirs(os.path.dirname(iter_path), exist_ok=True)
+        with open(iter_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
 
 
 
@@ -280,23 +285,29 @@ def execute_scripts(outputs_name, num_chunks):
 def str2bool(x):
     return x.lower() in ("1", "true", "yes")
 
-def parse_args():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--pretrained_model", type=str, default=optimization_config.pretrained_model)
     parser.add_argument("--dataset", type=str, default=optimization_config.train_dataset)
     parser.add_argument("--num_chunks", type=int, default=optimization_config.num_chunks)
     parser.add_argument("--scale_tuple_list", type=ast.literal_eval, default=optimization_config.scale_tuple_list)
-    return parser.parse_args()
+    parser.add_argument("--iteration", type=int, default=None)
+    return parser.parse_args(argv)
 
-args = parse_args()
-globals().update(vars(args))
+def main(argv=None):
+    args = parse_args(argv)
+    globals().update(vars(args))
 
 
-# read processed data
-outputs_name = "rl-" + pretrained_model.replace("/", ".") + "-" + dataset
+    # read processed data
+    outputs_name = "rl-" + pretrained_model.replace("/", ".") + "-" + dataset
+    
+    # execute
+    execute_scripts(outputs_name, num_chunks, iteration)
 
-# execute
-execute_scripts(outputs_name, num_chunks)
+
+if __name__ == "__main__":
+    main()
 
 
 

--- a/optimization/reward.py
+++ b/optimization/reward.py
@@ -26,7 +26,7 @@ import optimization_config
 def str2bool(x):
     return x.lower() in ("1", "true", "yes")
 
-def parse_args():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--pretrained_model", type=str, default=optimization_config.pretrained_model)
     parser.add_argument("--dataset", type=str, default=optimization_config.train_dataset)
@@ -36,153 +36,158 @@ def parse_args():
     parser.add_argument("--separate_training", type=str2bool, default=optimization_config.separate_training)
     parser.add_argument("--enable_efficient", type=str2bool, default=optimization_config.enable_efficient)
     parser.add_argument("--post_stage", type=str2bool, default=optimization_config.post_stage)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
-args = parse_args()
-globals().update(vars(args))
-
-
-
-# read the inference data
-
-outputs_name =  pretrained_model.replace("/", ".") + "-" + dataset
-
-os.makedirs(os.path.dirname("./temp_data/outputs-rl-" + outputs_name + ".json"), exist_ok=True)
-with open("./temp_data/outputs-rl-" + outputs_name + ".json", 'r') as f:
-    data = json.load(f)
+def main(argv=None):
+    args = parse_args(argv)
+    globals().update(vars(args))
 
 
 
-
-# obatin the rollout samples and the corresponding reward/advantages
-
-def normalize_reward(reward_arr):
-    if np.all(reward_arr == 1) and enable_efficient:
-        return reward_arr
-    mean = np.mean(reward_arr)
-    std = np.std(reward_arr)
-    if std.item() == 0:
-        return None
-    return (reward_arr - mean) / std
-
-def normalize_balance_std(x: np.ndarray) -> np.ndarray:
-    x = np.asarray(x, dtype=float)
-    pos_mask = x > 0
-    neg_mask = x < 0
-    sum_pos = x[pos_mask].sum()
-    sum_neg_abs = abs(x[neg_mask].sum())
-    if sum_pos * sum_neg_abs == 0:
-        return None
-    scale_factor = sum_neg_abs / sum_pos
-    x[pos_mask] *= scale_factor
-    return x / x.std()
-
-def length_regularize(reward_arr, response_length_list):
-    reward_arr = np.sign(reward_arr)
-    pos_list = np.where(reward_arr == 1)[0].tolist()
-    neg_list = np.where(reward_arr == -1)[0].tolist()
-    pos_response_length = np.array([response_length_list[j] for j in pos_list])
-    threshold = np.median(pos_response_length).item()
-    if np.sum((pos_response_length - threshold)**2) == 0: # no variance
-        return normalize_balance_std(np.sign(reward_arr))
-    threshold = max(min(threshold, max_len_threshold), min_len_threshold)
-    length_reg_reward = np.zeros(len(reward_arr), float)
-    length_reg_reward[pos_list] = - pos_response_length + threshold
-    length_reg_reward[neg_list] = np.min(length_reg_reward).copy()
-    length_reg_reward = normalize_balance_std(length_reg_reward)
-    return length_reg_reward
-
-code_data = []
-case_data = []
-index_list = []
-
-for i in range(len(data)):
-    if data[i]["all_case_bool_table"] is None:
-        continue
+    # read the inference data
     
-    t = data[i]["num_ground_truth_test"]
-    all_test_table_i = np.array(data[i]["all_case_bool_table"])[:, :t].copy()
-    all_case_table_i = np.array(data[i]["all_case_bool_table"])[:, t:].copy()
-
-    # reward for code
-    code_reward = np.mean(all_test_table_i, 1)
-    #code_reward = all_test_table_i.all(axis=1).astype(float)
-    code_reward = normalize_reward(code_reward)
-    if code_reward is not None:
-        if enable_efficient:
-            code_reward = length_regularize(code_reward, data[i]["code_response_length"])
-        if code_reward is not None:
-            code_reward = code_reward.tolist()
-            for j in range(len(code_reward)):
-                code_data_i = {}
-                code_data_i["prompt"] = data[i]["code_generation_prompt"]
-                if data[i]["code_response_length"][j] < max_generation_len:
-                    code_data_i["response"] = data[i]["full_code_generation"][j] + "<|im_end|>"
-                else:
-                    code_data_i["response"] = data[i]["full_code_generation"][j]
-                code_data_i["reward"] = code_reward[j]
-                code_data.append(code_data_i)
+    outputs_name =  pretrained_model.replace("/", ".") + "-" + dataset
     
-    # reward for case
-    correct_code_list = np.where(all_test_table_i.all(axis=1))[0].tolist()
-    if len(correct_code_list) > 0:
-        # get reward sign
-        correct_code_table = all_case_table_i[correct_code_list, :].copy()
-        index_list = np.where(np.all(correct_code_table, axis=0))[0].tolist()
-        reward_sign = -np.ones(correct_code_table.shape[1], dtype=float)
-        reward_sign[index_list] = 1
-        case_reward = reward_sign.copy()
-        # get reward scale
-        wrong_code_list = [j for j in range(all_case_table_i.shape[0]) if j not in correct_code_list]
-        if len(wrong_code_list) > 0:
-            reward_scale = np.ones(correct_code_table.shape[1], dtype=float)
-            correct_case_list = np.where(correct_code_table.all(axis=0))[0].tolist()
-            wrong_case_list = [j for j in range(all_case_table_i.shape[1]) if j not in correct_case_list]
-            if len(correct_case_list):
-                wrong_code_correct_case_table = all_case_table_i[wrong_code_list, :][:, correct_case_list].copy()
-                if post_stage == False:
-                    mean_p01 = np.mean(~wrong_code_correct_case_table, 0)
-                else:
-                    mean_p01 = (~np.any(wrong_code_correct_case_table, axis=0)).astype(float)
-                reward_scale[correct_case_list] = reward_scale[correct_case_list] * mean_p01
-            if len(wrong_case_list):
-                wrong_code_wrong_case_table = all_case_table_i[wrong_code_list, :][:, wrong_case_list].copy()
-                if post_stage == False:
-                    mean_p00 = np.mean(wrong_code_wrong_case_table, 0)
-                else:
-                    mean_p00 = (np.any(wrong_code_wrong_case_table, axis=0)).astype(float)
-                reward_scale[wrong_case_list] = reward_scale[wrong_case_list] * mean_p00
-            case_reward = case_reward * reward_scale
+    os.makedirs(os.path.dirname("./temp_data/outputs-rl-" + outputs_name + ".json"), exist_ok=True)
+    with open("./temp_data/outputs-rl-" + outputs_name + ".json", 'r') as f:
+        data = json.load(f)
+    
+    
+    
+    
+    # obatin the rollout samples and the corresponding reward/advantages
+    
+    def normalize_reward(reward_arr):
+        if np.all(reward_arr == 1) and enable_efficient:
+            return reward_arr
+        mean = np.mean(reward_arr)
+        std = np.std(reward_arr)
+        if std.item() == 0:
+            return None
+        return (reward_arr - mean) / std
+    
+    def normalize_balance_std(x: np.ndarray) -> np.ndarray:
+        x = np.asarray(x, dtype=float)
+        pos_mask = x > 0
+        neg_mask = x < 0
+        sum_pos = x[pos_mask].sum()
+        sum_neg_abs = abs(x[neg_mask].sum())
+        if sum_pos * sum_neg_abs == 0:
+            return None
+        scale_factor = sum_neg_abs / sum_pos
+        x[pos_mask] *= scale_factor
+        return x / x.std()
+    
+    def length_regularize(reward_arr, response_length_list):
+        reward_arr = np.sign(reward_arr)
+        pos_list = np.where(reward_arr == 1)[0].tolist()
+        neg_list = np.where(reward_arr == -1)[0].tolist()
+        pos_response_length = np.array([response_length_list[j] for j in pos_list])
+        threshold = np.median(pos_response_length).item()
+        if np.sum((pos_response_length - threshold)**2) == 0: # no variance
+            return normalize_balance_std(np.sign(reward_arr))
+        threshold = max(min(threshold, max_len_threshold), min_len_threshold)
+        length_reg_reward = np.zeros(len(reward_arr), float)
+        length_reg_reward[pos_list] = - pos_response_length + threshold
+        length_reg_reward[neg_list] = np.min(length_reg_reward).copy()
+        length_reg_reward = normalize_balance_std(length_reg_reward)
+        return length_reg_reward
+    
+    code_data = []
+    case_data = []
+    index_list = []
+    
+    for i in range(len(data)):
+        if data[i]["all_case_bool_table"] is None:
+            continue
         
-        case_reward = normalize_reward(case_reward)
-        if case_reward is not None:
+        t = data[i]["num_ground_truth_test"]
+        all_test_table_i = np.array(data[i]["all_case_bool_table"])[:, :t].copy()
+        all_case_table_i = np.array(data[i]["all_case_bool_table"])[:, t:].copy()
+    
+        # reward for code
+        code_reward = np.mean(all_test_table_i, 1)
+        #code_reward = all_test_table_i.all(axis=1).astype(float)
+        code_reward = normalize_reward(code_reward)
+        if code_reward is not None:
             if enable_efficient:
-                case_reward = length_regularize(case_reward, data[i]["case_response_length"])
-            if case_reward is not None:
-                case_reward = case_reward.tolist()
-                for j in range(len(case_reward)):
-                    case_data_i = {}
-                    case_data_i["prompt"] = data[i]["case_generation_prompt"]
-                    if data[i]["case_response_length"][j] < max_generation_len:
-                        case_data_i["response"] = data[i]["full_case_generation"][j] + "<|im_end|>"
+                code_reward = length_regularize(code_reward, data[i]["code_response_length"])
+            if code_reward is not None:
+                code_reward = code_reward.tolist()
+                for j in range(len(code_reward)):
+                    code_data_i = {}
+                    code_data_i["prompt"] = data[i]["code_generation_prompt"]
+                    if data[i]["code_response_length"][j] < max_generation_len:
+                        code_data_i["response"] = data[i]["full_code_generation"][j] + "<|im_end|>"
                     else:
-                        case_data_i["response"] = data[i]["full_case_generation"][j]
-                    case_data_i["reward"] = case_reward[j]
-                    case_data.append(case_data_i)
+                        code_data_i["response"] = data[i]["full_code_generation"][j]
+                    code_data_i["reward"] = code_reward[j]
+                    code_data.append(code_data_i)
+        
+        # reward for case
+        correct_code_list = np.where(all_test_table_i.all(axis=1))[0].tolist()
+        if len(correct_code_list) > 0:
+            # get reward sign
+            correct_code_table = all_case_table_i[correct_code_list, :].copy()
+            index_list = np.where(np.all(correct_code_table, axis=0))[0].tolist()
+            reward_sign = -np.ones(correct_code_table.shape[1], dtype=float)
+            reward_sign[index_list] = 1
+            case_reward = reward_sign.copy()
+            # get reward scale
+            wrong_code_list = [j for j in range(all_case_table_i.shape[0]) if j not in correct_code_list]
+            if len(wrong_code_list) > 0:
+                reward_scale = np.ones(correct_code_table.shape[1], dtype=float)
+                correct_case_list = np.where(correct_code_table.all(axis=0))[0].tolist()
+                wrong_case_list = [j for j in range(all_case_table_i.shape[1]) if j not in correct_case_list]
+                if len(correct_case_list):
+                    wrong_code_correct_case_table = all_case_table_i[wrong_code_list, :][:, correct_case_list].copy()
+                    if post_stage == False:
+                        mean_p01 = np.mean(~wrong_code_correct_case_table, 0)
+                    else:
+                        mean_p01 = (~np.any(wrong_code_correct_case_table, axis=0)).astype(float)
+                    reward_scale[correct_case_list] = reward_scale[correct_case_list] * mean_p01
+                if len(wrong_case_list):
+                    wrong_code_wrong_case_table = all_case_table_i[wrong_code_list, :][:, wrong_case_list].copy()
+                    if post_stage == False:
+                        mean_p00 = np.mean(wrong_code_wrong_case_table, 0)
+                    else:
+                        mean_p00 = (np.any(wrong_code_wrong_case_table, axis=0)).astype(float)
+                    reward_scale[wrong_case_list] = reward_scale[wrong_case_list] * mean_p00
+                case_reward = case_reward * reward_scale
+            
+            case_reward = normalize_reward(case_reward)
+            if case_reward is not None:
+                if enable_efficient:
+                    case_reward = length_regularize(case_reward, data[i]["case_response_length"])
+                if case_reward is not None:
+                    case_reward = case_reward.tolist()
+                    for j in range(len(case_reward)):
+                        case_data_i = {}
+                        case_data_i["prompt"] = data[i]["case_generation_prompt"]
+                        if data[i]["case_response_length"][j] < max_generation_len:
+                            case_data_i["response"] = data[i]["full_case_generation"][j] + "<|im_end|>"
+                        else:
+                            case_data_i["response"] = data[i]["full_case_generation"][j]
+                        case_data_i["reward"] = case_reward[j]
+                        case_data.append(case_data_i)
+    
+    
+    
+    
+    final_data = code_data + case_data
+    random.shuffle(final_data)
+    
+    if separate_training == False:
+        with open("./temp_data/rl_data.json", "w", encoding="utf-8") as f:
+            json.dump(final_data, f, indent=2, ensure_ascii=False)
+    else:
+        with open("./temp_data/rl_code_data.json", "w", encoding="utf-8") as f:
+            json.dump(code_data, f, indent=2, ensure_ascii=False)
+        with open("./temp_data/rl_case_data.json", "w", encoding="utf-8") as f:
+            json.dump(case_data, f, indent=2, ensure_ascii=False)
 
 
-
-
-final_data = code_data + case_data
-random.shuffle(final_data)
-
-if separate_training == False:
-    with open("./temp_data/rl_data.json", "w", encoding="utf-8") as f:
-        json.dump(final_data, f, indent=2, ensure_ascii=False)
-else:
-    with open("./temp_data/rl_code_data.json", "w", encoding="utf-8") as f:
-        json.dump(code_data, f, indent=2, ensure_ascii=False)
-    with open("./temp_data/rl_case_data.json", "w", encoding="utf-8") as f:
-        json.dump(case_data, f, indent=2, ensure_ascii=False)
-
-
+if __name__ == "__main__":
+    main()
+    
+    

--- a/optimization/sample.py
+++ b/optimization/sample.py
@@ -135,7 +135,7 @@ def random_select(data_list, random_k):
 def str2bool(x):
     return x.lower() in ("1", "true", "yes")
 
-def parse_args():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--pretrained_model", type=str, default=optimization_config.pretrained_model)
     parser.add_argument("--dataset", type=str, default=optimization_config.train_dataset)
@@ -153,35 +153,14 @@ def parse_args():
     parser.add_argument("--system_case_prompts", type=str, default=optimization_config.system_case_prompts)
     parser.add_argument("--special_requirements", type=str, default=optimization_config.special_requirements)
     parser.add_argument("--post_stage", type=str2bool, default=optimization_config.post_stage)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
-args = parse_args()
-globals().update(vars(args))
+def main(argv=None):
+    args = parse_args(argv)
+    globals().update(vars(args))
 
-if post_stage == True:
-    p_give_example = 0.0
-
-
-
-
-
-
-
-
-
-# read dataset
-with open("../data/" + dataset + ".json", 'r') as f:
-    data = json.load(f)
-#data = [data[i] for i in range(10)]
-random_select_num = min(random_select_num, len(data))
-data = random_select(data, random_select_num)
-num = len(data)
-
-
-# load model, tokenizer, build vllm engines...
-task_queues, result_queues, processes = start_workers(pretrained_model, gpu_groups, max_model_len, max_generation_token)
-tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
-outputs_name = "rl-" + pretrained_model.replace("/", ".") + "-" + dataset
+    if post_stage == True:
+        p_give_example = 0.0
 
 
 
@@ -191,236 +170,252 @@ outputs_name = "rl-" + pretrained_model.replace("/", ".") + "-" + dataset
 
 
 
-def bernoulli(p):
-    return 1 if random.random() < p else 0
-
-# obtain prompt
-def get_scaling_prompt(data_i, method):
-    problem = data_i["question"]
-    if method == "sample":
-        return Template(system_prompts).render(language = "python", special_requirements = special_requirements, problem = problem)
-    if method == "case":
-        n_example = len(data_i["example_input"])
-        example_input = ", ".join([repr(item) for item in data_i['example_input']])
-        example_output = ", ".join([repr(item) for item in data_i['example_output']])
-        if n_example == 0:
-            example_intro = """ """
-        if n_example == 1:
-            example_intro = """We already have one test sample:\n Its input is {{example_input}}. Its output is {{example_output}}.\n"""
-            example_intro = Template(example_intro).render(example_input = example_input, example_output = example_output)
-        if n_example > 1:
-            example_intro = """We already have {{n_sample}} test samples:\n The inputs are, respectively, {{example_input}}. The corresponding outputs are {{example_output}}.\n"""
-            example_intro = Template(example_intro).render(n_sample = n_example, example_input = example_input, example_output = example_output)
-        return Template(system_case_prompts).render(problem = problem, example_intro = example_intro)
-
-def modify(c):
-    # Remove any occurrences of "plaintext\n"
-    c = c.replace("plaintext\n", "")
+    # read dataset
+    with open("../data/" + dataset + ".json", 'r') as f:
+        data = json.load(f)
+    #data = [data[i] for i in range(10)]
+    random_select_num = min(random_select_num, len(data))
+    data = random_select(data, random_select_num)
+    num = len(data)
     
-    # Convert literal "\n" to actual newlines
-    c = c.replace("\\n", "\n")
     
-    # Ensure there's a trailing newline
-    if not c.endswith("\n"):
-        c += "\n"
+    # load model, tokenizer, build vllm engines...
+    task_queues, result_queues, processes = start_workers(pretrained_model, gpu_groups, max_model_len, max_generation_token)
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
+    outputs_name = "rl-" + pretrained_model.replace("/", ".") + "-" + dataset
     
-    return c
-
-# extract the unit tests from responses
-def extract_test_cases(full_output):
-    # First, try extracting with the updated triple-backtick pattern
-    pattern_input_backticks = r'\*\*Test Input:\*\*\s*```(.*?)```'
-    pattern_output_backticks = r'\*\*Test Output:\*\*\s*```(.*?)```'
-    matches_input = re.findall(pattern_input_backticks, full_output, re.DOTALL)
-    matches_output = re.findall(pattern_output_backticks, full_output, re.DOTALL)
-
-    fail_case = [""]
-    # For Test Input: either use the updated triple-backtick version or fallback to plain text
-    if matches_input:
-        test_input = [modify(matches_input[-1].lstrip('\n'))]
-    else:
-        # Fallback pattern without backticks: capture until **Test Output:**
-        pattern_input_plain = r'\*\*Test Input:\*\*\s*([\s\S]*?)(?=\*\*Test Output:\*\*)'
-        matches_input_plain = re.findall(pattern_input_plain, full_output, re.DOTALL)
-        if matches_input_plain:
-            test_input = [modify(matches_input_plain[-1].strip())]
+    
+    
+    
+    
+    
+    
+    
+    
+    def bernoulli(p):
+        return 1 if random.random() < p else 0
+    
+    # obtain prompt
+    def get_scaling_prompt(data_i, method):
+        problem = data_i["question"]
+        if method == "sample":
+            return Template(system_prompts).render(language = "python", special_requirements = special_requirements, problem = problem)
+        if method == "case":
+            n_example = len(data_i["example_input"])
+            example_input = ", ".join([repr(item) for item in data_i['example_input']])
+            example_output = ", ".join([repr(item) for item in data_i['example_output']])
+            if n_example == 0:
+                example_intro = """ """
+            if n_example == 1:
+                example_intro = """We already have one test sample:\n Its input is {{example_input}}. Its output is {{example_output}}.\n"""
+                example_intro = Template(example_intro).render(example_input = example_input, example_output = example_output)
+            if n_example > 1:
+                example_intro = """We already have {{n_sample}} test samples:\n The inputs are, respectively, {{example_input}}. The corresponding outputs are {{example_output}}.\n"""
+                example_intro = Template(example_intro).render(n_sample = n_example, example_input = example_input, example_output = example_output)
+            return Template(system_case_prompts).render(problem = problem, example_intro = example_intro)
+    
+    def modify(c):
+        # Remove any occurrences of "plaintext\n"
+        c = c.replace("plaintext\n", "")
+        
+        # Convert literal "\n" to actual newlines
+        c = c.replace("\\n", "\n")
+        
+        # Ensure there's a trailing newline
+        if not c.endswith("\n"):
+            c += "\n"
+        
+        return c
+    
+    # extract the unit tests from responses
+    def extract_test_cases(full_output):
+        # First, try extracting with the updated triple-backtick pattern
+        pattern_input_backticks = r'\*\*Test Input:\*\*\s*```(.*?)```'
+        pattern_output_backticks = r'\*\*Test Output:\*\*\s*```(.*?)```'
+        matches_input = re.findall(pattern_input_backticks, full_output, re.DOTALL)
+        matches_output = re.findall(pattern_output_backticks, full_output, re.DOTALL)
+    
+        fail_case = [""]
+        # For Test Input: either use the updated triple-backtick version or fallback to plain text
+        if matches_input:
+            test_input = [modify(matches_input[-1].lstrip('\n'))]
         else:
-            test_input = fail_case
-    
-    # For Test Output: either use the updated triple-backtick version or fallback to plain text
-    if matches_output:
-        test_output = [modify(matches_output[-1].lstrip('\n'))]
-    else:
-        # Fallback: capture until the **Explanation:** marker or end-of-string
-        pattern_output_plain = r'\*\*Test Output:\*\*\s*([\s\S]*?)(?=\*\*Explanation:|\*\*Test Input:|$)'
-        matches_output_plain = re.findall(pattern_output_plain, full_output, re.DOTALL)
-        if matches_output_plain:
-            test_output = [modify(matches_output_plain[-1].strip())]
+            # Fallback pattern without backticks: capture until **Test Output:**
+            pattern_input_plain = r'\*\*Test Input:\*\*\s*([\s\S]*?)(?=\*\*Test Output:\*\*)'
+            matches_input_plain = re.findall(pattern_input_plain, full_output, re.DOTALL)
+            if matches_input_plain:
+                test_input = [modify(matches_input_plain[-1].strip())]
+            else:
+                test_input = fail_case
+        
+        # For Test Output: either use the updated triple-backtick version or fallback to plain text
+        if matches_output:
+            test_output = [modify(matches_output[-1].lstrip('\n'))]
         else:
-            test_output = fail_case
+            # Fallback: capture until the **Explanation:** marker or end-of-string
+            pattern_output_plain = r'\*\*Test Output:\*\*\s*([\s\S]*?)(?=\*\*Explanation:|\*\*Test Input:|$)'
+            matches_output_plain = re.findall(pattern_output_plain, full_output, re.DOTALL)
+            if matches_output_plain:
+                test_output = [modify(matches_output_plain[-1].strip())]
+            else:
+                test_output = fail_case
+        
+        # Also extract from the last occurrence of **Test Input:** to the end
+        index = full_output.rfind("**Test Input:**")
+        if index != -1:
+            example_text = [full_output[index:]]
+        else:
+            example_text = fail_case
+        
+        # If any essential piece is missing, return empties
+        if example_text == fail_case or test_input == fail_case or test_output == fail_case:
+            return fail_case, fail_case, fail_case
+        
+        return test_input, test_output, example_text
     
-    # Also extract from the last occurrence of **Test Input:** to the end
-    index = full_output.rfind("**Test Input:**")
-    if index != -1:
-        example_text = [full_output[index:]]
-    else:
-        example_text = fail_case
     
-    # If any essential piece is missing, return empties
-    if example_text == fail_case or test_input == fail_case or test_output == fail_case:
-        return fail_case, fail_case, fail_case
     
-    return test_input, test_output, example_text
+    
+    
+    
+    # initialization
+    code_generation_prompts = []
+    code_index = []
+    case_generation_prompts = []
+    case_index = []
+    for i in range(num):
+        # preprocess
+        data[i]["full_code_generation"] = []
+        data[i]["code_response_length"] = []
+        data[i]["full_case_generation"] = []
+        data[i]["case_response_length"] = []
+        data[i]["generated_code"] = []
+        max_k = min(max_ground_truth_test, len(data[i]["test_input"]))
+        data[i]["num_ground_truth_test"] = max_k 
+        data[i]["all_case_input"] = (data[i]["test_input"][:max_k]).copy()
+        data[i]["all_case_output"] = (data[i]["test_output"][:max_k]).copy()
+        data[i]["case_input"] = []
+        data[i]["case_output"] = []
+        data[i]["case_text"] = []
+    
+        data_i = data[i].copy()
+        # get code generation prompts
+        prompt_i = get_scaling_prompt(data_i, "sample")
+        data[i]["code_generation_prompt"] = prompt_i
+        code_generation_prompts = code_generation_prompts + [prompt_i] * k_code
+        code_index = code_index + [i] * k_code
+        # get case generation prompts
+        #k_case_generate = k_case - min(k_case, len(data_i["example_input"]))
+        k_case_generate = k_case
+        if_give_example = bernoulli(p_give_example)
+        if if_give_example == 0:
+            data_i["example_input"] = []
+            data_i["example_output"] = []
+            data[i]["no_example"] = True
+        else:
+            max_input_examples_n = min(max_input_examples, len(data_i["example_input"]))
+            data_i["example_input"] = data_i["example_input"][:max_input_examples_n]
+            data_i["example_output"] = data_i["example_output"][:max_input_examples_n]
+            data[i]["no_example"] = False
+        prompt_i = get_scaling_prompt(data_i, "case")
+        data[i]["case_generation_prompt"] = prompt_i
+    
+        if k_case_generate > 0:
+            case_generation_prompts = case_generation_prompts + [prompt_i] * k_case_generate
+            case_index = case_index + [i] * k_case_generate
+    
+    
+    
+    
+    
+    
+    
+    
+    # sampling process
+    
+    cprint("start generation...", "green")
+    
+    # shuffle first, to achieve efficiency
+    all_prompts = code_generation_prompts + case_generation_prompts
+    N = len(all_prompts)
+    indices = list(range(N))
+    shuffled_idx = indices[:]      
+    random.shuffle(shuffled_idx)
+    shuffled_prompts = [all_prompts[i] for i in shuffled_idx]
+    # generate
+    shuffled_outputs = generate_results(shuffled_prompts, gpu_groups, task_queues, result_queues)
+    restored_outputs = [None] * N
+    for out, idx in zip(shuffled_outputs, shuffled_idx):
+        restored_outputs[idx] = out
+    code_generation_result = restored_outputs[:len(code_generation_prompts)]
+    case_generation_result = restored_outputs[len(code_generation_prompts):]
+    
+    cprint("generation job done!", "green")
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    # calculate the response length
+    
+    def get_token_lengths(strings, tokenizer):
+        return [len(tokenizer.encode(s, add_special_tokens=False)) for s in strings]
+    
+    code_response_length = get_token_lengths(code_generation_result, tokenizer)
+    case_response_length = get_token_lengths(case_generation_result, tokenizer)
+    mean_code = sum(code_response_length)/len(code_response_length)
+    mean_case = sum(case_response_length)/len(case_response_length)
+    
+    os.makedirs(os.path.dirname("./results/results-" + outputs_name + ".txt"), exist_ok=True)
+    with open("./results/results-" + outputs_name + ".txt", "a") as f:
+        # Save + print
+        def save_and_print(text):
+            cprint(text, color="green")
+            f.write(text + "\n")
+        save_and_print(f"code response length: {mean_code}, case response length: {mean_case}")
+    
+    
+    
+    
+    
+    # process generated codes
+    i = 0
+    for full_output in code_generation_result:
+        code_output = extract_code(full_output)
+        index_i = code_index[i]
+        data[index_i]["full_code_generation"] = data[index_i]["full_code_generation"] + [full_output]
+        data[index_i]["generated_code"] = data[index_i]["generated_code"] + [code_output]
+        data[index_i]["code_response_length"].append(code_response_length[i])
+        i += 1
+    
+    # process generated unit tests
+    i = 0
+    for full_output in case_generation_result:
+        test_input, test_output, example_text = extract_test_cases(full_output)
+        index_i = case_index[i]
+        data[index_i]["full_case_generation"] = data[index_i]["full_case_generation"] + [full_output]
+        data[index_i]["case_input"] = data[index_i]["case_input"] + test_input
+        data[index_i]["case_output"] = data[index_i]["case_output"] + test_output
+        data[index_i]["case_text"] = data[index_i]["case_text"] + example_text
+        data[index_i]["all_case_input"] = data[index_i]["all_case_input"] + test_input
+        data[index_i]["all_case_output"] = data[index_i]["all_case_output"] + test_output
+        data[index_i]["case_response_length"].append(case_response_length[i])
+        i += 1
+    
+    # output the data
+    os.makedirs(os.path.dirname("./temp_data/outputs-" + outputs_name + ".json"), exist_ok=True)
+    with open("./temp_data/outputs-" + outputs_name + ".json", "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    
+    
+    
+    stop_workers(task_queues, processes)
 
 
-
-
-
-
-# initialization
-code_generation_prompts = []
-code_index = []
-case_generation_prompts = []
-case_index = []
-for i in range(num):
-    # preprocess
-    data[i]["full_code_generation"] = []
-    data[i]["code_response_length"] = []
-    data[i]["full_case_generation"] = []
-    data[i]["case_response_length"] = []
-    data[i]["generated_code"] = []
-    max_k = min(max_ground_truth_test, len(data[i]["test_input"]))
-    data[i]["num_ground_truth_test"] = max_k 
-    data[i]["all_case_input"] = (data[i]["test_input"][:max_k]).copy()
-    data[i]["all_case_output"] = (data[i]["test_output"][:max_k]).copy()
-    data[i]["case_input"] = []
-    data[i]["case_output"] = []
-    data[i]["case_text"] = []
-
-    data_i = data[i].copy()
-    # get code generation prompts
-    prompt_i = get_scaling_prompt(data_i, "sample")
-    data[i]["code_generation_prompt"] = prompt_i
-    code_generation_prompts = code_generation_prompts + [prompt_i] * k_code
-    code_index = code_index + [i] * k_code
-    # get case generation prompts
-    #k_case_generate = k_case - min(k_case, len(data_i["example_input"]))
-    k_case_generate = k_case
-    if_give_example = bernoulli(p_give_example)
-    if if_give_example == 0:
-        data_i["example_input"] = []
-        data_i["example_output"] = []
-        data[i]["no_example"] = True
-    else:
-        max_input_examples_n = min(max_input_examples, len(data_i["example_input"]))
-        data_i["example_input"] = data_i["example_input"][:max_input_examples_n]
-        data_i["example_output"] = data_i["example_output"][:max_input_examples_n]
-        data[i]["no_example"] = False
-    prompt_i = get_scaling_prompt(data_i, "case")
-    data[i]["case_generation_prompt"] = prompt_i
-
-    if k_case_generate > 0:
-        case_generation_prompts = case_generation_prompts + [prompt_i] * k_case_generate
-        case_index = case_index + [i] * k_case_generate
-
-
-
-
-
-
-
-
-# sampling process
-
-cprint("start generation...", "green")
-
-# shuffle first, to achieve efficiency
-all_prompts = code_generation_prompts + case_generation_prompts
-N = len(all_prompts)
-indices = list(range(N))
-shuffled_idx = indices[:]      
-random.shuffle(shuffled_idx)
-shuffled_prompts = [all_prompts[i] for i in shuffled_idx]
-# generate
-shuffled_outputs = generate_results(shuffled_prompts, gpu_groups, task_queues, result_queues)
-restored_outputs = [None] * N
-for out, idx in zip(shuffled_outputs, shuffled_idx):
-    restored_outputs[idx] = out
-code_generation_result = restored_outputs[:len(code_generation_prompts)]
-case_generation_result = restored_outputs[len(code_generation_prompts):]
-
-cprint("generation job done!", "green")
-
-
-
-
-
-
-
-
-
-
-# calculate the response length
-
-def get_token_lengths(strings, tokenizer):
-    return [len(tokenizer.encode(s, add_special_tokens=False)) for s in strings]
-
-code_response_length = get_token_lengths(code_generation_result, tokenizer)
-case_response_length = get_token_lengths(case_generation_result, tokenizer)
-mean_code = sum(code_response_length)/len(code_response_length)
-mean_case = sum(case_response_length)/len(case_response_length)
-
-os.makedirs(os.path.dirname("./results/results-" + outputs_name + ".txt"), exist_ok=True)
-with open("./results/results-" + outputs_name + ".txt", "a") as f:
-    # Save + print
-    def save_and_print(text):
-        cprint(text, color="green")
-        f.write(text + "\n")
-    save_and_print(f"code response length: {mean_code}, case response length: {mean_case}")
-
-
-
-
-
-# process generated codes
-i = 0
-for full_output in code_generation_result:
-    code_output = extract_code(full_output)
-    index_i = code_index[i]
-    data[index_i]["full_code_generation"] = data[index_i]["full_code_generation"] + [full_output]
-    data[index_i]["generated_code"] = data[index_i]["generated_code"] + [code_output]
-    data[index_i]["code_response_length"].append(code_response_length[i])
-    i += 1
-
-# process generated unit tests
-i = 0
-for full_output in case_generation_result:
-    test_input, test_output, example_text = extract_test_cases(full_output)
-    index_i = case_index[i]
-    data[index_i]["full_case_generation"] = data[index_i]["full_case_generation"] + [full_output]
-    data[index_i]["case_input"] = data[index_i]["case_input"] + test_input
-    data[index_i]["case_output"] = data[index_i]["case_output"] + test_output
-    data[index_i]["case_text"] = data[index_i]["case_text"] + example_text
-    data[index_i]["all_case_input"] = data[index_i]["all_case_input"] + test_input
-    data[index_i]["all_case_output"] = data[index_i]["all_case_output"] + test_output
-    data[index_i]["case_response_length"].append(case_response_length[i])
-    i += 1
-
-# output the data
-os.makedirs(os.path.dirname("./temp_data/outputs-" + outputs_name + ".json"), exist_ok=True)
-with open("./temp_data/outputs-" + outputs_name + ".json", "w", encoding="utf-8") as f:
-    json.dump(data, f, indent=2, ensure_ascii=False)
-
-
-
-stop_workers(task_queues, processes)
-
-
-
-
-
-
-
-
-
-
+if __name__ == "__main__":
+    main()

--- a/optimization/train.py
+++ b/optimization/train.py
@@ -112,12 +112,12 @@ class PPOExp(BasePPOExp):
         )
 
 
-if __name__ == "__main__":
+def main(argv=None):
 
     import argparse, sys, asyncio, os
     parser = argparse.ArgumentParser()
     parser.add_argument("--pretrain", type=str)
-    args, unknown = parser.parse_known_args()
+    args, unknown = parser.parse_known_args(argv)
 
     sys.argv = [sys.argv[0]] + unknown
 
@@ -126,7 +126,7 @@ if __name__ == "__main__":
         cfg.pretrain = args.pretrain
 
     exp = PPOExp().set_cfg(cfg)
-    
+
     logger.info(exp.get_cfg_as_str(exp.cfg))
     if not os.path.exists(exp.cfg.save_path):
         os.makedirs(exp.cfg.save_path, exist_ok=True)
@@ -135,3 +135,7 @@ if __name__ == "__main__":
     if not os.path.exists(exp.cfg.ckpt_path):
         os.makedirs(exp.cfg.ckpt_path, exist_ok=True)
     asyncio.run(exp.run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `execute.py` to save output with an iteration-specific filename
- pass current iteration from `run.py` to `execute.py`
- expose optimization scripts as callable APIs instead of subprocesses

## Testing
- `python -m py_compile run.py optimization/execute.py optimization/reward.py optimization/train.py optimization/sample.py`

------
https://chatgpt.com/codex/tasks/task_e_685d4f5c87988332a40b69fc9eada377