### PR TITLE
Refactor optimization flow to use in-memory data

### DIFF
--- a/optimization/sample.py
+++ b/optimization/sample.py
@@ -407,14 +407,9 @@ def main(argv=None):
         data[index_i]["case_response_length"].append(case_response_length[i])
         i += 1
     
-    # output the data
-    os.makedirs(os.path.dirname("./temp_data/outputs-" + outputs_name + ".json"), exist_ok=True)
-    with open("./temp_data/outputs-" + outputs_name + ".json", "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-    
-    
-    
+    # stop workers and return data instead of writing to disk
     stop_workers(task_queues, processes)
+    return data
 
 
 if __name__ == "__main__":

--- a/optimization/train_utils/rl/trainer.py
+++ b/optimization/train_utils/rl/trainer.py
@@ -56,21 +56,18 @@ class RayPPOTrainer:
     async def eval(self):
         raise NotImplementedError("Eval function should be implemented in user's exp")
 
-    async def train(self):
+    async def train(self, rl_data):
 
-        if self.cfg.separate_training == True:
-            train_data_list = [self.cfg.rl_code_data, self.cfg.rl_case_data]
+        if self.cfg.separate_training:
+            code_data, case_data = rl_data
+            train_data_list = [code_data, case_data]
         else:
-            train_data_list = [self.cfg.rl_data]
-        
-        for data_name in train_data_list:
+            train_data_list = [rl_data]
 
-            logger.info(f"Training with {data_name}")
+        for dataset in train_data_list:
+            logger.info("Training with provided dataset")
 
-            with open(data_name, 'r') as f:
-                rl_data = json.load(f)
-
-            await self.make_experience(rl_data)
+            await self.make_experience(dataset)
 
             num_policy_dp_nodes = self.cfg.actor_num_nodes * self.cfg.actor_num_gpus_per_node
             num_critic_dp_nodes = self.cfg.critic_num_nodes * self.cfg.critic_num_gpus_per_node


### PR DESCRIPTION
## Summary
- refactor `sample.py` to return data instead of writing to files
- change `execute.py` to process data directly and return it
- update `reward.py` to output RL data without saving
- allow `RayPPOTrainer.train` and `train.py` to consume data lists
- simplify `run.py` to pass data through modules without temporary files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fa864201883329562469440e8fcb6